### PR TITLE
New TF operator rate limiter

### DIFF
--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"os"
+	"strconv"
 
 	appv1alpha1 "github.com/hashicorp/terraform-k8s/api/v1alpha1"
 	"github.com/hashicorp/terraform-k8s/workspacehelper"
@@ -17,7 +19,16 @@ import (
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("workspace-controller", mgr, controller.Options{Reconciler: r})
+	// Ratelimiter: retry every 30mins. Wait time grows exp up to a week.
+	baseDelayMultiplier, err := strconv.Atoi(os.Getenv("BASE_DELAY_MULTIPLIER"))
+	maxDelayMultiplier, err := strconv.Atoi(os.Getenv("MAX_DELAY_MULTIPLIER"))
+	startingTokens, err := strconv.Atoi(os.Getenv("TOKENS"))
+	tokenRefilRate, err := strconv.Atoi(os.Getenv("TOKENS_REFIL_RATE"))
+	c, err := controller.New("workspace-controller", mgr,
+		controller.Options{
+			Reconciler: r,
+			RateLimiter: workspacehelper.WorkspaceRateLimiter(
+				baseDelayMultiplier, maxDelayMultiplier , startingTokens, tokenRefilRate)})
 	if err != nil {
 		return err
 	}

--- a/workspacehelper/tfc_output.go
+++ b/workspacehelper/tfc_output.go
@@ -45,7 +45,7 @@ func convertValueToString(val cty.Value) string {
 					return convertValueToString(jv)
 				}
 			}
-			return `"` + val.AsString() + `"`
+			return val.AsString()
 		case cty.Bool:
 			if val.True() {
 				return "true"

--- a/workspacehelper/workspace_helper.go
+++ b/workspacehelper/workspace_helper.go
@@ -491,7 +491,7 @@ func (r *WorkspaceHelper) Reconcile(ctx context.Context, request reconcile.Reque
 	if err != nil {
 		return reconcile.Result{}, err
 	} else if shouldRequeue {
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(1)*time.Second}, nil
 	}
 
 	// process the run result

--- a/workspacehelper/workspace_ratelimiter.go
+++ b/workspacehelper/workspace_ratelimiter.go
@@ -1,0 +1,22 @@
+package workspacehelper
+
+import (
+	"time"
+	"golang.org/x/time/rate"
+
+	rl "k8s.io/client-go/util/workqueue"
+
+)
+
+// WorkspaceRateLimiter is a constructor for a rate limiter for a workqueue. It has
+// both overall and per-item rate limiting. The overall is a token bucket and the per-item is exponential
+func WorkspaceRateLimiter(baseDelayMultiplier int, maxDelayMultiplier int, startingTokens int, tokensRefilRate int) rl.RateLimiter {
+	return rl.NewMaxOfRateLimiter(
+		rl.NewItemExponentialFailureRateLimiter(
+			time.Duration(baseDelayMultiplier)*time.Second, 
+			time.Duration(maxDelayMultiplier)*time.Minute),
+		// tokensRefilRate qps, startingTokens bucket size.  
+		// This is only for retry speed and its only the overall factor (not per item)
+		&rl.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(tokensRefilRate), startingTokens)},
+	)
+}


### PR DESCRIPTION
The fork has been updated with the latest changes from hashicorp main.

New changes are:
- Introduced a custom `WorkspaceRateLimiter` for the TF Operator. 
- We've also modified the workspace Reconciler to requeue after 1sec.

Old changes:
- I've also added an old change to avoid regression